### PR TITLE
Remove tiered GCYL Glass

### DIFF
--- a/src/main/java/com/fulltrix/gcyl/CommonProxy.java
+++ b/src/main/java/com/fulltrix/gcyl/CommonProxy.java
@@ -79,7 +79,7 @@ public class CommonProxy {
         IForgeRegistry<Block> registry = event.getRegistry();
         registry.register(HEATING_COIL);
         registry.register(MULTIBLOCK_CASING2);
-        registry.register(TRANSPARENT_CASING);
+        //registry.register(TRANSPARENT_CASING);
         registry.register(FUSION_CASING);
         registry.register(VACUUM_CASING);
         registry.register(DIVERTOR_CASING);
@@ -96,7 +96,7 @@ public class CommonProxy {
         IForgeRegistry<Item> registry = event.getRegistry();
         registry.register(createItemBlock(HEATING_COIL, VariantItemBlock::new));
         registry.register(createItemBlock(MULTIBLOCK_CASING2, VariantItemBlock::new));
-        registry.register(createItemBlock(TRANSPARENT_CASING, VariantItemBlock::new));
+        //registry.register(createItemBlock(TRANSPARENT_CASING, VariantItemBlock::new));
         registry.register(createItemBlock(FUSION_CASING, VariantItemBlock::new));
         registry.register(createItemBlock(VACUUM_CASING, VariantItemBlock::new));
         registry.register(createItemBlock(DIVERTOR_CASING, VariantItemBlock::new));

--- a/src/main/java/com/fulltrix/gcyl/item/GCYLMetaBlocks.java
+++ b/src/main/java/com/fulltrix/gcyl/item/GCYLMetaBlocks.java
@@ -18,7 +18,7 @@ import static gregtech.common.blocks.MetaBlocks.statePropertiesToString;
 
 public class GCYLMetaBlocks {
     public static GCYLMultiblockCasing2 MULTIBLOCK_CASING2;
-    public static GCYLTransparentCasing TRANSPARENT_CASING;
+    //public static GCYLTransparentCasing TRANSPARENT_CASING;
     public static GCYLHeatingCoil HEATING_COIL;
     public static GCYLFusionCasing FUSION_CASING;
     public static GCYLVacuumCasing VACUUM_CASING;
@@ -36,8 +36,8 @@ public class GCYLMetaBlocks {
         HEATING_COIL = new GCYLHeatingCoil();
         HEATING_COIL.setRegistryName("wire_coil");
 
-        TRANSPARENT_CASING = new GCYLTransparentCasing();
-        TRANSPARENT_CASING.setRegistryName("gcyl_transparent_casing");
+        //TRANSPARENT_CASING = new GCYLTransparentCasing();
+        //TRANSPARENT_CASING.setRegistryName("gcyl_transparent_casing");
 
         MULTIBLOCK_CASING2 = new GCYLMultiblockCasing2();
         MULTIBLOCK_CASING2.setRegistryName("gcyl_multiblock_casing2");
@@ -75,7 +75,7 @@ public class GCYLMetaBlocks {
     public static void registerItemModels() {
 
         registerItemModel(MULTIBLOCK_CASING2);
-        registerItemModel(TRANSPARENT_CASING);
+        //registerItemModel(TRANSPARENT_CASING);
         registerItemModel(FUSION_CASING);
         registerItemModel(VACUUM_CASING);
         registerItemModel(DIVERTOR_CASING);

--- a/src/main/java/com/fulltrix/gcyl/machines/multi/MetaTileEntityBioReactor.java
+++ b/src/main/java/com/fulltrix/gcyl/machines/multi/MetaTileEntityBioReactor.java
@@ -13,6 +13,8 @@ import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.client.renderer.ICubeRenderer;
 import gregtech.client.renderer.texture.cube.OrientedOverlayRenderer;
+import gregtech.common.blocks.BlockGlassCasing;
+import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 
@@ -43,7 +45,7 @@ public class MetaTileEntityBioReactor extends RecipeMapMultiblockController {
                 .where('X', states(getCasingState()).or(autoAbilities(true, true, true, true, true, true, false)))
                 .where('L', states(getCasingState()).setMinGlobalLimited(34))
                 .where('#', air())
-                .where('G', states(GCYLMetaBlocks.TRANSPARENT_CASING.getState(GCYLTransparentCasing.CasingType.OSMIRIDIUM_GLASS)))
+                .where('G', states(MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.LAMINATED_GLASS)))
                 .build();
     }
 

--- a/src/main/java/com/fulltrix/gcyl/machines/multi/advance/MetaTileEntityHyperReactor.java
+++ b/src/main/java/com/fulltrix/gcyl/machines/multi/advance/MetaTileEntityHyperReactor.java
@@ -16,6 +16,8 @@ import gregtech.api.pattern.BlockPattern;
 import gregtech.api.pattern.FactoryBlockPattern;
 import gregtech.api.util.GTUtility;
 import gregtech.client.renderer.ICubeRenderer;
+import gregtech.common.blocks.BlockGlassCasing;
+import gregtech.common.blocks.MetaBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
@@ -151,7 +153,7 @@ public class MetaTileEntityHyperReactor extends FuelMultiblockController impleme
                         .where('S', selfPredicate())
                         .where('F', frames(Naquadria))
                         .where('H', states(GCYLMetaBlocks.REACTOR_CASING.getState(GCYLReactorCasing.CasingType.HYPER_CORE_3)))
-                        .where('G', states(GCYLMetaBlocks.TRANSPARENT_CASING.getState(GCYLTransparentCasing.CasingType.OSMIRIDIUM_GLASS)))
+                        .where('G', states(MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.LAMINATED_GLASS)))
                         .where('c', states(getCasingState(b)).setMinGlobalLimited(250))
                         .build();
             }
@@ -165,7 +167,7 @@ public class MetaTileEntityHyperReactor extends FuelMultiblockController impleme
                         .where('S', selfPredicate())
                         .where('C', states(getCasingState(c)).or(autoAbilities(false,true,true,true,true,true,false)
                                 .or(abilities(MultiblockAbility.OUTPUT_ENERGY).setExactLimit(1))))
-                        .where('G', states(GCYLMetaBlocks.TRANSPARENT_CASING.getState(GCYLTransparentCasing.CasingType.OSMIRIDIUM_GLASS)))
+                        .where('G', states(MetaBlocks.TRANSPARENT_CASING.getState(BlockGlassCasing.CasingType.LAMINATED_GLASS)))
                         .where('H', states(GCYLMetaBlocks.REACTOR_CASING.getState(GCYLReactorCasing.CasingType.HYPER_CORE)))
                         .where('#', air())
                         .where('c', states(getCasingState(c)).setMinGlobalLimited(25))

--- a/src/main/java/com/fulltrix/gcyl/recipes/helper/GCYLCraftingComponents.java
+++ b/src/main/java/com/fulltrix/gcyl/recipes/helper/GCYLCraftingComponents.java
@@ -22,6 +22,7 @@ import static gregtech.api.unification.ore.OrePrefix.plate;
 
 
 public enum GCYLCraftingComponents {
+    /*
     CIRCUIT {
         @Override
         public Object getIngredient(int tier) {
@@ -999,5 +1000,7 @@ public enum GCYLCraftingComponents {
     };
 
     public abstract Object getIngredient(int tier);
+
+     */
 }
 

--- a/src/main/java/com/fulltrix/gcyl/recipes/helper/HelperMethods.java
+++ b/src/main/java/com/fulltrix/gcyl/recipes/helper/HelperMethods.java
@@ -63,6 +63,7 @@ public class HelperMethods {
                 .buildAndRegister();
     }
 
+    /*
     // Don't mind the extra "s" on the method name, just Java not recognizing
     // 2 Lists with different generic types as different parameters for overloading.
     public static void registerMachineRecipes(List<MetaTileEntityEnergyHatch> metaTileEntities, Object... recipe) {
@@ -81,5 +82,7 @@ public class HelperMethods {
         }
         return recipe;
     }
+
+     */
 
 }


### PR DESCRIPTION
Fixes #2 

Removed all glass tiers added by GCYL. The tiered glass system from gregicality is boring and did not do anything as it did not limit voltage, it was just a requirement for multiblocks. These glass tiers did not go above osmiridium. A glass tiering system will be implemented in the future that at least adds glass that have complexity like laminated glass. 